### PR TITLE
Improve search styling

### DIFF
--- a/docs/src/layout/header/search/ResponsiveSearch.tsx
+++ b/docs/src/layout/header/search/ResponsiveSearch.tsx
@@ -21,15 +21,15 @@ export const ResponsiveSearch = () => {
     const showSearch = search.length > 0 && data;
 
     return (
-        <div id="searchbar" className="w-full text-[#18181b]">
-            <div className="relative z-10 rounded-xl border-2 border-transparent bg-white">
+        <div id="searchbar" className="w-full text-[#18181b] dark:text-white">
+            <div className="relative z-10 rounded-xl bg-transparent">
                 <input
                     type="text"
                     onClick={() => {
                         setSelect(-1);
                     }}
-                    className="outline-ens-500 w-full rounded-xl py-2 pl-10 text-xl outline-offset-4"
-                    placeholder="Search for anything..."
+                    className="dark:bg-searchbar w-full rounded-xl border-none py-2 pl-10 text-xl outline-none"
+                    placeholder="Search Content..."
                     // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus={true}
                     id="search-input"

--- a/docs/src/layout/header/search/Search.tsx
+++ b/docs/src/layout/header/search/Search.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
 import { SearchModal } from './SearchModal';
@@ -53,24 +54,25 @@ export function Search() {
 
     return (
         <div className="hidden lg:block lg:max-w-md lg:flex-auto">
-            {isOpen === false ? (
-                <button
-                    type="button"
-                    className="outline-ens-500 hidden h-8 w-full items-center gap-2 rounded-lg bg-white pl-2 text-sm text-zinc-500 ring-1 ring-zinc-900/10 transition hover:ring-zinc-900/20 dark:bg-white/5 dark:text-zinc-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex"
-                    onClick={() => setOpen(true)}
-                >
-                    <SearchIcon className="h-5 w-5 stroke-current" />
-                    Search Content...
-                    <span className="ml-auto inline-flex p-1">
+            <button
+                type="button"
+                className={clsx(
+                    'outline-ens-500 h-8 w-full items-center gap-2 rounded-lg bg-white pl-2 text-sm text-zinc-500 ring-1 ring-zinc-900/10 hover:ring-zinc-900/20 dark:bg-white/5 dark:text-zinc-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex',
+                    isOpen ? 'opacity-0' : 'opacity-100'
+                )}
+                onClick={() => setOpen(true)}
+            >
+                <SearchIcon className="h-5 w-5 stroke-current" />
+                Search Content...
+                <span className="ml-auto inline-flex p-1">
+                    {modifierKey && (
                         <kbd className="border-ens-light-border text-2xs dark:border-ens-dark-border my-1 flex h-full items-center rounded-md border px-1">
                             <kbd className="font-sans">{modifierKey}</kbd>+
                             <kbd className="font-sans">k</kbd>
                         </kbd>
-                    </span>
-                </button>
-            ) : (
-                <></>
-            )}
+                    )}
+                </span>
+            </button>
             <SearchModal open={isOpen} onClose={() => setOpen(false)} />
         </div>
     );
@@ -81,7 +83,7 @@ export function MobileSearch() {
         <div className="contents lg:hidden">
             <button
                 type="button"
-                className="flex h-6 w-6 items-center justify-center rounded-md transition hover:bg-zinc-900/5 dark:hover:bg-white/5 lg:hidden"
+                className="flex h-6 w-6 items-center justify-center rounded-md transition-all hover:bg-zinc-900/5 dark:hover:bg-white/5 lg:hidden"
                 aria-label="Search Content..."
             >
                 <SearchIcon className="h-5 w-5 stroke-zinc-900 dark:stroke-white" />

--- a/docs/src/layout/header/search/Search.tsx
+++ b/docs/src/layout/header/search/Search.tsx
@@ -53,20 +53,24 @@ export function Search() {
 
     return (
         <div className="hidden lg:block lg:max-w-md lg:flex-auto">
-            <button
-                type="button"
-                className="outline-ens-500 hidden h-8 w-full items-center gap-2 rounded-lg bg-white pl-2 text-sm text-zinc-500 ring-1 ring-zinc-900/10 transition hover:ring-zinc-900/20 focus:outline-2 dark:bg-white/5 dark:text-zinc-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex"
-                onClick={() => setOpen(true)}
-            >
-                <SearchIcon className="h-5 w-5 stroke-current" />
-                Search Content...
-                <span className="ml-auto inline-flex p-1">
-                    <kbd className="my-1 flex h-full items-center rounded-md border border-ens-light-border px-1 text-2xs dark:border-ens-dark-border">
-                        <kbd className="font-sans">{modifierKey}</kbd>+
-                        <kbd className="font-sans">k</kbd>
-                    </kbd>
-                </span>
-            </button>
+            {isOpen === false ? (
+                <button
+                    type="button"
+                    className="outline-ens-500 hidden h-8 w-full items-center gap-2 rounded-lg bg-white pl-2 text-sm text-zinc-500 ring-1 ring-zinc-900/10 transition hover:ring-zinc-900/20 dark:bg-white/5 dark:text-zinc-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex"
+                    onClick={() => setOpen(true)}
+                >
+                    <SearchIcon className="h-5 w-5 stroke-current" />
+                    Search Content...
+                    <span className="ml-auto inline-flex p-1">
+                        <kbd className="border-ens-light-border text-2xs dark:border-ens-dark-border my-1 flex h-full items-center rounded-md border px-1">
+                            <kbd className="font-sans">{modifierKey}</kbd>+
+                            <kbd className="font-sans">k</kbd>
+                        </kbd>
+                    </span>
+                </button>
+            ) : (
+                <></>
+            )}
             <SearchModal open={isOpen} onClose={() => setOpen(false)} />
         </div>
     );
@@ -77,7 +81,7 @@ export function MobileSearch() {
         <div className="contents lg:hidden">
             <button
                 type="button"
-                className="flex h-6 w-6 items-center justify-center rounded-md transition hover:bg-zinc-900/5 dark:hover:bg-white/5 lg:hidden focus:[&:not(:focus-visible)]:outline-none"
+                className="flex h-6 w-6 items-center justify-center rounded-md transition hover:bg-zinc-900/5 dark:hover:bg-white/5 lg:hidden"
                 aria-label="Search Content..."
             >
                 <SearchIcon className="h-5 w-5 stroke-zinc-900 dark:stroke-white" />

--- a/docs/src/layout/header/search/SearchResults.tsx
+++ b/docs/src/layout/header/search/SearchResults.tsx
@@ -1,4 +1,5 @@
 'use client';
+import clsx from 'clsx';
 import Link from 'next/link';
 import { FC, useEffect } from 'react';
 
@@ -99,7 +100,12 @@ export const SearchResults: FC<{
                                                 hit._formatted.content ??
                                                 hit._formatted.description,
                                         }}
-                                        className="dark:text-ens-light-blue-light block h-[2em] w-full truncate pl-8 text-[#3f3f46]"
+                                        className={clsx(
+                                            'block h-[2em] w-full truncate pl-8 text-[#3f3f46]',
+                                            hit.slug.startsWith('dao')
+                                                ? 'dark:text-ens-light-purple-light'
+                                                : 'dark:text-ens-light-blue-light'
+                                        )}
                                     />
                                 </span>
                                 <span className="flex gap-2">

--- a/docs/src/layout/header/search/SearchResults.tsx
+++ b/docs/src/layout/header/search/SearchResults.tsx
@@ -64,18 +64,18 @@ export const SearchResults: FC<{
 
     return (
         <>
-            <div className="w-full bg-neutral-50 pt-4">
+            <div className="dark:bg-ens-dark-grey-surface w-full bg-neutral-50 pt-4">
                 {data.hits.length === 0 && (
-                    <div className="flex w-full flex-col items-center bg-neutral-50 py-8 text-center">
+                    <div className="dark:bg-ens-dark-grey-surface flex w-full flex-col items-center bg-neutral-50 py-8 text-center">
                         <div className="text-4xl">🤷‍♀️</div>
                         <div className="">No results found</div>
                         <div className="text-sm">Try a different search</div>
                     </div>
                 )}
-                <ul className="bg-neutral-50 py-2">
+                <ul className="dark:bg-ens-dark-grey-surface bg-neutral-50 py-2">
                     {data.hits.map((hit, index) => (
                         <li
-                            className="hlem outline-0 focus-within:bg-neutral-100"
+                            className="hlem outline-0 focus-within:bg-neutral-200 dark:focus-within:bg-neutral-800"
                             id={'search-result-' + index}
                             key={hit.slug}
                         >
@@ -99,12 +99,12 @@ export const SearchResults: FC<{
                                                 hit._formatted.content ??
                                                 hit._formatted.description,
                                         }}
-                                        className="block h-[2em] w-full truncate pl-8 text-[#3f3f46]"
+                                        className="dark:text-ens-light-blue-light block h-[2em] w-full truncate pl-8 text-[#3f3f46]"
                                     />
                                 </span>
                                 <span className="flex gap-2">
                                     {hit.slug.startsWith('dao') && (
-                                        <span className="h-fit rounded-md bg-ens-dao-400 px-2 py-0.5 text-xs font-bold text-white">
+                                        <span className="bg-ens-dao-400 h-fit rounded-md px-2 py-0.5 text-xs font-bold text-white">
                                             DAO
                                         </span>
                                     )}
@@ -114,7 +114,7 @@ export const SearchResults: FC<{
                     ))}
                 </ul>
             </div>
-            <div className="flex w-full justify-between rounded-b-xl border-t bg-neutral-50 px-4 py-1 text-2xs text-neutral-400">
+            <div className="text-2xs dark:bg-ens-dark-background-secondary flex w-full justify-between rounded-b-xl border-t bg-neutral-50 px-4 py-1 text-neutral-400">
                 <div>{data.estimatedTotalHits} hits for search</div>
                 <div>{data.processingTimeMs}ms</div>
             </div>

--- a/docs/src/layout/header/search/SearchResults.tsx
+++ b/docs/src/layout/header/search/SearchResults.tsx
@@ -32,9 +32,6 @@ export const SearchResults: FC<{
                 case 'Enter': {
                     break;
                 }
-                default: {
-                    setSelect(-1);
-                }
             }
         };
 
@@ -63,6 +60,10 @@ export const SearchResults: FC<{
         }
     }, [select]);
 
+    useEffect(() => {
+        setSelect(-1);
+    }, [data.hits]);
+
     return (
         <>
             <div className="dark:bg-ens-dark-grey-surface w-full bg-neutral-50 pt-4">
@@ -81,6 +82,9 @@ export const SearchResults: FC<{
                             key={hit.slug}
                         >
                             <Link
+                                onFocus={() => {
+                                    setSelect(index);
+                                }}
                                 href={'/' + hit.slug}
                                 id={'search-result-link-' + index}
                                 className="z-10 flex w-full px-4 py-1"
@@ -120,7 +124,7 @@ export const SearchResults: FC<{
                     ))}
                 </ul>
             </div>
-            <div className="text-2xs dark:bg-ens-dark-background-secondary flex w-full justify-between rounded-b-xl border-t bg-neutral-50 px-4 py-1 text-neutral-400">
+            <div className="text-2xs dark:bg-ens-dark-background-secondary border-t-ens-light-border dark:border-t-ens-dark-border flex w-full justify-between rounded-b-xl border-t bg-neutral-50 px-4 py-1 text-neutral-400">
                 <div>{data.estimatedTotalHits} hits for search</div>
                 <div>{data.processingTimeMs}ms</div>
             </div>

--- a/docs/src/layout/sidebar/_legacy/navgroup.tsx
+++ b/docs/src/layout/sidebar/_legacy/navgroup.tsx
@@ -21,7 +21,7 @@ function NavLink({ href, tag, active, isAnchorLink = false, children }) {
             href={href}
             aria-current={active ? 'page' : undefined}
             className={clsx(
-                'flex justify-between gap-2 rounded-lg border-none py-1.5 pr-0 text-sm outline-none ring-ens-light-blue-primary ring-offset-1 transition focus:ring dark:ring-ens-dark-blue-primary',
+                'ring-ens-light-blue-primary dark:ring-ens-dark-blue-primary flex justify-between gap-2 rounded-lg border-none py-1.5 pr-0 text-sm outline-none ring-offset-1 transition',
                 isAnchorLink ? 'pl-8' : 'pl-4',
                 active
                     ? 'bg-ens-light-blue-surface text-ens-light-text-primary dark:bg-ens-dark-blue-surface dark:text-ens-dark-text-primary'
@@ -51,7 +51,7 @@ function ActivePageMarker({ group, pathname }) {
     return (
         <motion.div
             layout
-            className="absolute left-2 h-6 w-px bg-ens-light-blue-500"
+            className="bg-ens-light-blue-500 absolute left-2 h-6 w-px"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1, transition: { delay: 0.2 } }}
             exit={{ opacity: 0 }}
@@ -81,7 +81,7 @@ export const NavigationGroup = ({ group, className }) => {
             {group.title && (
                 <motion.h2
                     layout="position"
-                    className="py-2 pl-2 text-xs font-bold leading-5 text-ens-light-text-secondary dark:text-ens-dark-text-secondary dark:text-white"
+                    className="text-ens-light-text-secondary dark:text-ens-dark-text-secondary py-2 pl-2 text-xs font-bold leading-5 dark:text-white"
                 >
                     {/* {group.icon && group.icon + ' '} */}
                     {group.title}
@@ -99,12 +99,12 @@ export const NavigationGroup = ({ group, className }) => {
                                 <span>{link.title}</span>
                                 {link.external && <FiExternalLink />}
                                 {link.wip && (
-                                    <div className="rounded-md bg-ens-light-blue-surface px-1 text-3xs font-bold text-ens-light-blue-primary dark:bg-ens-dark-blue-surface dark:text-ens-dark-blue-primary">
+                                    <div className="bg-ens-light-blue-surface text-3xs text-ens-light-blue-primary dark:bg-ens-dark-blue-surface dark:text-ens-dark-blue-primary rounded-md px-1 font-bold">
                                         {link.wip == 1 ? 'WIP' : `${link.wip}%`}
                                     </div>
                                 )}
                                 {link.design_wip && (
-                                    <div className="h-1.5 w-1.5 rounded-full bg-ens-light-pink-primary dark:bg-ens-dark-pink-primary"></div>
+                                    <div className="bg-ens-light-pink-primary dark:bg-ens-dark-pink-primary h-1.5 w-1.5 rounded-full"></div>
                                 )}
                             </NavLink>
                         </li>

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -49,7 +49,7 @@ module.exports = {
                 15: '0.15',
             },
             colors: {
-                //1E2122
+                searchbar: '#262929',
                 ens: {
                     light: {
                         blue: {


### PR DESCRIPTION
Hey there! I decided to improve search styling by making darkmode prettier and also removing the "Open search" fake searchbar button when the search modal is opened.

Old:
![image](https://github.com/ensdomains/docs-v2/assets/84264740/b566b880-f20f-468e-a343-ce19c6321182)
New:
![image](https://github.com/ensdomains/docs-v2/assets/84264740/ae907062-39ba-4e7e-aad6-b56312bb74d4)

I also took the liberty of changing the description color in dark mode to a light blue or light purple depending on if the hit is DAO-related or not, however this change can easily be reverted if it's too colorful.

Hope y'all like it!